### PR TITLE
[fix] Replace filtered content in Koala operation

### DIFF
--- a/src/utils/operations/filter_text/mod_koala.py
+++ b/src/utils/operations/filter_text/mod_koala.py
@@ -49,8 +49,11 @@ class KoalaModerationFilter(FilterTextOperation):
         # Handle top classification
         top_label, _ = label_prob_pairs[0]
         filtered = top_label != self.GOOD_LABEL
-        
-        yield {
-            "content": content, 
-            "filtered": filtered
-        }
+
+        result = {"filtered": filtered}
+        if filtered:
+            result |= {"content": "Filtered.", "original_content": content}
+        else:
+            result |= {"content": content}
+
+        yield result


### PR DESCRIPTION
Content was being passed unchanged even when filtered. Now correctly replaces to-be-spoken content with "Filtered." on top of the filtered status and original content.