### PR TITLE
[fix] Fix MCP interfacing

### DIFF
--- a/src/utils/mcp/manager.py
+++ b/src/utils/mcp/manager.py
@@ -14,6 +14,7 @@ from mcp.types import (
     TextResourceContents,
     BlobResourceContents
 )
+from utils.prompter.message import RawMessage
 
 from utils.config import Config
 from utils.operations import OperationManager, OpRoles
@@ -168,8 +169,8 @@ class MCPClient:
                 response_stream = OperationManager().use_operation(
                     OpRoles.MCP,
                     {
-                        "system_prompt": message.systemPrompt,
-                        "user_prompt": message.messages[0].content.text 
+                        "instruction_prompt": message.systemPrompt,
+                        "messages": [RawMessage(message.messages[0].content.text)] 
                     }
                 )
 

--- a/src/utils/prompter/message.py
+++ b/src/utils/prompter/message.py
@@ -77,7 +77,7 @@ class MCPMessage(Message):
             "type": "tool",
             "tool": self.tool_name,
             "time": self.time.timestamp(),
-            "message": self.message
+            "message": self.result
         }
     
 class CustomMessage(Message):


### PR DESCRIPTION
In MCP sampler, usage of T2T operation used old spec. Updated input to use new spec.

Updated attributes returned in MCPMessage, fixing #29 